### PR TITLE
为滑动交互手势添加惯性滑动效果

### DIFF
--- a/XWTransition/Category/UIViewController+XWTransition.h
+++ b/XWTransition/Category/UIViewController+XWTransition.h
@@ -55,7 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param edgeSpacing     手势触发的边缘距离，该值为0，表示在整个控制器视图上都有效，否者这在边缘的edgeSpacing之类有效
  */
 
-- (void)xw_registerToInteractiveTransitionWithDirection:(XWInteractiveTransitionGestureDirection)direction transitonBlock:(void(^)(CGPoint startPoint))tansitionConfig edgeSpacing:(CGFloat)edgeSpacing;
+- (XWInteractiveTransition *)xw_registerToInteractiveTransitionWithDirection:(XWInteractiveTransitionGestureDirection)direction transitonBlock:(void(^)(CGPoint startPoint))tansitionConfig edgeSpacing:(CGFloat)edgeSpacing;
 
 /**
  *  注册back手势(pop或者dismiss手势)
@@ -64,7 +64,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param tansitionConfig 手势触发的block，block中需要包含你的pop或者dismiss的逻辑代码，注意避免循环引用问题
  *  @param edgeSpacing     手势触发的边缘距离，该值为0，表示在整个控制器视图上都有效，否者这在边缘的edgeSpacing之类有效
  */
-- (void)xw_registerBackInteractiveTransitionWithDirection:(XWInteractiveTransitionGestureDirection)direction transitonBlock:(void(^)(CGPoint startPoint))tansitionConfig edgeSpacing:(CGFloat)edgeSpacing;
+- (XWInteractiveTransition *)xw_registerBackInteractiveTransitionWithDirection:(XWInteractiveTransitionGestureDirection)direction transitonBlock:(void(^)(CGPoint startPoint))tansitionConfig edgeSpacing:(CGFloat)edgeSpacing;
 
 @end
 

--- a/XWTransition/Category/UIViewController+XWTransition.m
+++ b/XWTransition/Category/UIViewController+XWTransition.m
@@ -12,21 +12,24 @@
 
 @implementation UIViewController (XWTransition)
 
-- (void)xw_registerToInteractiveTransitionWithDirection:(XWInteractiveTransitionGestureDirection)direction transitonBlock:(void(^)(CGPoint startPoint))tansitionConfig edgeSpacing:(CGFloat)edgeSpacing{
-    if (!tansitionConfig) return;
+- (XWInteractiveTransition *)xw_registerToInteractiveTransitionWithDirection:(XWInteractiveTransitionGestureDirection)direction transitonBlock:(void(^)(CGPoint startPoint))tansitionConfig edgeSpacing:(CGFloat)edgeSpacing{
+    if (!tansitionConfig) return nil;
     XWInteractiveTransition *interactive = [XWInteractiveTransition xw_interactiveTransitionWithDirection:direction config:tansitionConfig edgeSpacing:edgeSpacing];
     [interactive xw_addPanGestureForView:self.view to:YES];
     objc_setAssociatedObject(self, &kXWToInteractiveKey, interactive, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     
+    return interactive;
 }
 
-- (void)xw_registerBackInteractiveTransitionWithDirection:(XWInteractiveTransitionGestureDirection)direction transitonBlock:(void(^)(CGPoint startPoint))tansitionConfig edgeSpacing:(CGFloat)edgeSpacing{
-    if (!tansitionConfig) return;
+- (XWInteractiveTransition *)xw_registerBackInteractiveTransitionWithDirection:(XWInteractiveTransitionGestureDirection)direction transitonBlock:(void(^)(CGPoint startPoint))tansitionConfig edgeSpacing:(CGFloat)edgeSpacing{
+    if (!tansitionConfig) return nil;
     XWInteractiveTransition *interactive = [XWInteractiveTransition xw_interactiveTransitionWithDirection:direction config:tansitionConfig edgeSpacing:edgeSpacing];
     [interactive xw_addPanGestureForView:self.view to:NO];
     XWTransitionAnimator *animator = objc_getAssociatedObject(self, &kXWAnimatorKey);if (animator) {
         [animator setValue:interactive forKey:@"backInteractive"];
     }
+    
+    return interactive;
 }
 
 - (void)xw_presentViewController:(UIViewController *)viewController withAnimator:(XWTransitionAnimator *)animator {

--- a/XWTransition/Main/XWInteractiveTransition.h
+++ b/XWTransition/Main/XWInteractiveTransition.h
@@ -44,6 +44,11 @@ typedef NS_ENUM(NSUInteger, XWInteractiveTransitionGestureDirection) {
 /**设置该值可改变计算手势百分比的基准，手势基准的原理：百分比 = 拖动距离 / panRatioBaseValue， 默认情况下水平方向panRatioBaseValue为手势所在view的宽度，垂直方向为手势所在view的高度，通常无需更改该值，在某些特殊情况下，如果想要调整手势的速率可以更改该值，比如让手势速率加倍，可以调整该值为view宽度高度的一半*/
 @property (nonatomic, assign) CGFloat panRatioBaseValue;
 
+/**惯性滑动的比率，取值范围为0~1，值越大则惯性滑动的距离越大，0表示没有惯性，默认为0*/
+@property (nonatomic, assign) CGFloat inertiaRatio;
+/**惯性滑动的时间，默认为0*/
+@property (nonatomic, assign) CGFloat inertiaDuration;
+
 + (instancetype)xw_interactiveTransitionWithDirection:(XWInteractiveTransitionGestureDirection)direction config:(void(^)(CGPoint startPoint))config edgeSpacing:(CGFloat)edgeSpacing;
 
 - (void)xw_addPanGestureForView:(UIView *)view to:(BOOL)flag;

--- a/XWTransition/Main/XWInteractiveTransition.m
+++ b/XWTransition/Main/XWInteractiveTransition.m
@@ -112,6 +112,38 @@ typedef struct {
             break;
         }
         case UIGestureRecognizerStateEnded:{
+            //手势的滑动速率
+            CGPoint velocity = [panGesture velocityInView:nil];
+            CGFloat speed = 0;
+            switch (_direction) {
+                case XWInteractiveTransitionGestureDirectionLeft:
+                    speed = -velocity.x;
+                    break;
+                case XWInteractiveTransitionGestureDirectionRight:
+                    speed = velocity.x;
+                    break;
+                case XWInteractiveTransitionGestureDirectionUp:
+                    speed = -velocity.y;
+                    break;
+                case XWInteractiveTransitionGestureDirectionDown:
+                    speed = velocity.y;
+                    break;
+                default:
+                    break;
+            }
+            //滑动速度，即每秒的滑动距离
+            speed = speed > 0 ? speed : 0;
+            //惯性的比例
+            CGFloat ratio = _inertiaRatio;
+            ratio = ratio > 1 ? 1 : ratio;
+            ratio = ratio < 0 ? 0 : ratio;
+            //惯性的持续时间
+            CGFloat duration = _inertiaDuration > 0 ? _inertiaDuration : 0;
+            //根据惯性比例及持续时间算出的惯性滑动距离
+            CGFloat offset = speed * ratio * duration;
+            //更新Percent
+            [self _xw_caculateMovePercentForGesture:panGesture offset:offset];
+            
             //判断是否需要timer
             if (!_timerEable) {
                 _percent >= 0.5 ? [self _xw_finish] : [self _xw_cancle];
@@ -164,6 +196,39 @@ typedef struct {
             break;
         case XWInteractiveTransitionGestureDirectionDown:{
             CGFloat transitionY = [panGesture translationInView:panGesture.view].y;
+            _percent += transitionY / baseValue;
+        }
+            break;
+    }
+    [panGesture setTranslation:CGPointZero inView:panGesture.view];
+}
+
+- (void)_xw_caculateMovePercentForGesture:(UIPanGestureRecognizer *)panGesture offset:(CGFloat)offset {
+    static CGFloat baseValue = 0.0f;
+    baseValue = _panRatioBaseValue > 0 ? _panRatioBaseValue : _vertical ? panGesture.view.frame.size.height : panGesture.view.frame.size.width;
+    //手势百分比
+    switch (_direction) {
+        case XWInteractiveTransitionGestureDirectionLeft:{
+            CGFloat transitionX = -[panGesture translationInView:panGesture.view].x;
+            transitionX += offset;
+            _percent += transitionX / baseValue;
+        }
+            break;
+        case XWInteractiveTransitionGestureDirectionRight:{
+            CGFloat transitionX = [panGesture translationInView:panGesture.view].x;
+            transitionX += offset;
+            _percent += transitionX / baseValue;
+        }
+            break;
+        case XWInteractiveTransitionGestureDirectionUp:{
+            CGFloat transitionY = -[panGesture translationInView:panGesture.view].y;
+            transitionY += offset;
+            _percent += transitionY / baseValue;
+        }
+            break;
+        case XWInteractiveTransitionGestureDirectionDown:{
+            CGFloat transitionY = [panGesture translationInView:panGesture.view].y;
+            transitionY += offset;
             _percent += transitionY / baseValue;
         }
             break;

--- a/XWTransitionDemo/DrawerTransition/XWDrawerFromController.m
+++ b/XWTransitionDemo/DrawerTransition/XWDrawerFromController.m
@@ -18,9 +18,12 @@
     [self.button setTitle:title forState:UIControlStateNormal];
     __weak typeof(self)weakSelf = self;
     XWInteractiveTransitionGestureDirection direction = _type ? XWInteractiveTransitionGestureDirectionUp : XWInteractiveTransitionGestureDirectionRight;
-    [self xw_registerToInteractiveTransitionWithDirection:direction transitonBlock:^(CGPoint startPoint){
+    XWInteractiveTransition *interactive = [self xw_registerToInteractiveTransitionWithDirection:direction transitonBlock:^(CGPoint startPoint){
         [weakSelf xw_transition];
     } edgeSpacing:_type ? 0 : 80];
+    //添加惯性效果
+    interactive.inertiaRatio = 0.6;
+    interactive.inertiaDuration = 0.8;
 }
 
 - (void)viewDidAppear:(BOOL)animated{

--- a/XWTransitionDemo/DrawerTransition/XWDrawerToController.m
+++ b/XWTransitionDemo/DrawerTransition/XWDrawerToController.m
@@ -18,9 +18,12 @@
     self.button.hidden = YES;
     XWInteractiveTransitionGestureDirection direction = _type ? XWInteractiveTransitionGestureDirectionDown : XWInteractiveTransitionGestureDirectionLeft;
     __weak typeof(self)weakSelf = self;
-    [self xw_registerBackInteractiveTransitionWithDirection:direction transitonBlock:^(CGPoint startPoint){
+    XWInteractiveTransition *interactive = [self xw_registerBackInteractiveTransitionWithDirection:direction transitonBlock:^(CGPoint startPoint){
         [weakSelf xw_transiton];
     } edgeSpacing:0];
+    //添加惯性效果
+    interactive.inertiaRatio = 0.7;
+    interactive.inertiaDuration = 0.7;
 }
 
 @end

--- a/XWTransitionDemo/FilterTransition/XWFilterFromController.m
+++ b/XWTransitionDemo/FilterTransition/XWFilterFromController.m
@@ -23,9 +23,12 @@
     [self.button setTitle:[NSString stringWithFormat:@"点我或向%@滑动", directionNames[_type]] forState:UIControlStateNormal];
     [self.button addTarget:self action:@selector(xw_transition) forControlEvents:UIControlEventTouchUpInside];
     __weak typeof(self)weakSelf = self;
-    [self xw_registerToInteractiveTransitionWithDirection:[self xw_getDirectionWithName:directionNames[_type]] transitonBlock:^(CGPoint startPoint){
+    XWInteractiveTransition *interactive = [self xw_registerToInteractiveTransitionWithDirection:[self xw_getDirectionWithName:directionNames[_type]] transitonBlock:^(CGPoint startPoint){
         [weakSelf xw_transition];
     } edgeSpacing:0];
+    //添加惯性效果
+    interactive.inertiaRatio = 0.7;
+    interactive.inertiaDuration = 0.7;
 }
 
 - (void)xw_transition{

--- a/XWTransitionDemo/FilterTransition/XWFilterToController.m
+++ b/XWTransitionDemo/FilterTransition/XWFilterToController.m
@@ -21,9 +21,12 @@
     [self.button setTitle:[NSString stringWithFormat:@"点我或向%@滑动", directionNames[_type]] forState:UIControlStateNormal];
     [self.button addTarget:self action:@selector(xw_transiton) forControlEvents:UIControlEventTouchUpInside];
     __weak typeof(self)weakSelf = self;
-    [self xw_registerBackInteractiveTransitionWithDirection:[self xw_getDirectionWithName:directionNames[_type]] transitonBlock:^(CGPoint startPoint){
+    XWInteractiveTransition *interactive = [self xw_registerBackInteractiveTransitionWithDirection:[self xw_getDirectionWithName:directionNames[_type]] transitonBlock:^(CGPoint startPoint){
         [weakSelf xw_transiton];
     } edgeSpacing:0];
+    //添加惯性效果
+    interactive.inertiaRatio = 0.7;
+    interactive.inertiaDuration = 0.8;
 }
 
 - (NSInteger)xw_getDirectionWithName:(NSString *)name{

--- a/XWTransitionDemo/MagicMoveTransiton/XWMagicMoveFromController.m
+++ b/XWTransitionDemo/MagicMoveTransiton/XWMagicMoveFromController.m
@@ -43,9 +43,12 @@
     [self xw_addMagicMoveEndViewGroup:@[imgView]];
     [self xw_addMagicMoveStartViewGroup:@[imgView, view1, view2]];
     __weak typeof(self)weakSelf = self;
-    [self xw_registerToInteractiveTransitionWithDirection:XWInteractiveTransitionGestureDirectionDown transitonBlock:^(CGPoint startPoint){
+    XWInteractiveTransition *interactive = [self xw_registerToInteractiveTransitionWithDirection:XWInteractiveTransitionGestureDirectionDown transitonBlock:^(CGPoint startPoint){
         [weakSelf xw_transition];
     } edgeSpacing:0];
+    //添加惯性效果
+    interactive.inertiaRatio = 0.5;
+    interactive.inertiaDuration = 0.8;
 }
 
 - (void)xw_setImage:(UIImage *)img {

--- a/XWTransitionDemo/MagicMoveTransiton/XWMagicMoveToController.m
+++ b/XWTransitionDemo/MagicMoveTransiton/XWMagicMoveToController.m
@@ -34,9 +34,12 @@
     [self.button setTitle:@"点我或向上滑动" forState:UIControlStateNormal];
     [self xw_addMagicMoveEndViewGroup:@[imgView, view1, view2]];
     __weak typeof(self)weakSelf = self;
-    [self xw_registerBackInteractiveTransitionWithDirection:XWInteractiveTransitionGestureDirectionUp transitonBlock:^(CGPoint startPoint){
+    XWInteractiveTransition *interactive = [self xw_registerBackInteractiveTransitionWithDirection:XWInteractiveTransitionGestureDirectionUp transitonBlock:^(CGPoint startPoint){
         [weakSelf xw_transiton];
     } edgeSpacing:0];
+    //添加惯性效果
+    interactive.inertiaRatio = 0.5;
+    interactive.inertiaDuration = 0.8;
 }
 
 - (void)xw_setImage:(UIImage *)img {


### PR DESCRIPTION
当手指滑动并离开屏幕时，模拟惯性效果使view能再滑动指定距离，让交互手势的操作更加顺滑